### PR TITLE
udpate rtd container version config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@
 version: 2
 
 build:
-  os: ubuntu-latest
+  os: ubuntu-lts-latest
   tools:
     python: "3"
 


### PR DESCRIPTION
Fixing the same issue as https://github.com/adafruit/cookiecutter-adafruit-circuitpython/pull/242

This is one of the only libraries that got the incorrect value from cookiecutter.