### PR TITLE
fix read_fifo to always define packet before return, Correct typo in dosctring

### DIFF
--- a/adafruit_rfm/rfm69.py
+++ b/adafruit_rfm/rfm69.py
@@ -639,7 +639,7 @@ class RFM69(RFMSPI):
         # Write payload to transmit fifo
         self.write_from(_RF69_REG_00_FIFO, complete_payload)
 
-    def read_fifo(self) -> bytearray:
+    def read_fifo(self) -> Optional[bytearray]:
         """Read the packet from the FIFO."""
         # Read the length of the FIFO.
         fifo_length = self.read_u8(_RF69_REG_00_FIFO)

--- a/adafruit_rfm/rfm69.py
+++ b/adafruit_rfm/rfm69.py
@@ -643,6 +643,7 @@ class RFM69(RFMSPI):
         """Read the packet from the FIFO."""
         # Read the length of the FIFO.
         fifo_length = self.read_u8(_RF69_REG_00_FIFO)
+        packet = None  # return None if FIFO empty
         if fifo_length > 0:  # read and clear the FIFO if anything in it
             packet = bytearray(fifo_length)
             # read the packet

--- a/adafruit_rfm/rfm9x.py
+++ b/adafruit_rfm/rfm9x.py
@@ -23,7 +23,7 @@ try:
     from circuitpython_typing import ReadableBuffer
 
     try:
-        from typing import Literal
+        from typing import Literal, Optional
     except ImportError:
         from typing_extensions import Literal
 

--- a/adafruit_rfm/rfm9x.py
+++ b/adafruit_rfm/rfm9x.py
@@ -517,7 +517,7 @@ class RFM9x(RFMSPI):
         # Write payload and header length.
         self.write_u8(_RF95_REG_22_PAYLOAD_LENGTH, len(payload))
 
-    def read_fifo(self) -> bytearray:
+    def read_fifo(self) -> Optional[bytearray]:
         """Read the data from the FIFO."""
         # Read the length of the FIFO.
         fifo_length = self.read_u8(_RF95_REG_13_RX_NB_BYTES)

--- a/adafruit_rfm/rfm9x.py
+++ b/adafruit_rfm/rfm9x.py
@@ -131,7 +131,7 @@ class RFM9x(RFMSPI):
     - preamble_length: The length in bytes of the packet preamble (default 8).
     - high_power: Boolean to indicate a high power board (RFM95, etc.).  Default
     is True for high power.
-    - baudrate: Baud rate of the SPI connection, default is 10mhz but you might
+    - baudrate: Baud rate of the SPI connection, default is 5mhz but you might
     choose to lower to 1mhz if using long wires or a breadboard.
     - agc: Boolean to Enable/Disable Automatic Gain Control - Default=False (AGC off)
     - crc: Boolean to Enable/Disable Cyclic Redundancy Check - Default=True (CRC Enabled)
@@ -521,6 +521,7 @@ class RFM9x(RFMSPI):
         """Read the data from the FIFO."""
         # Read the length of the FIFO.
         fifo_length = self.read_u8(_RF95_REG_13_RX_NB_BYTES)
+        packet = None  # return None if FIFO empty
         if fifo_length > 0:  # read and clear the FIFO if anything in it
             packet = bytearray(fifo_length)
             current_addr = self.read_u8(_RF95_REG_10_FIFO_RX_CURRENT_ADDR)

--- a/adafruit_rfm/rfm9xfsk.py
+++ b/adafruit_rfm/rfm9xfsk.py
@@ -567,6 +567,7 @@ class RFM9xFSK(RFMSPI):
         """Read the data from the FIFO."""
         # Read the length of the FIFO.
         fifo_length = self.read_u8(_RF95_REG_00_FIFO)
+        packet = None  # return None if FIFO empty
         if fifo_length > 0:  # read and clear the FIFO if anything in it
             packet = bytearray(fifo_length)
             # read the packet

--- a/adafruit_rfm/rfm9xfsk.py
+++ b/adafruit_rfm/rfm9xfsk.py
@@ -563,7 +563,7 @@ class RFM9xFSK(RFMSPI):
         # Write payload to transmit fifo
         self.write_from(_RF95_REG_00_FIFO, complete_payload)
 
-    def read_fifo(self) -> bytearray:
+    def read_fifo(self) -> Optional[bytearray]:
         """Read the data from the FIFO."""
         # Read the length of the FIFO.
         fifo_length = self.read_u8(_RF95_REG_00_FIFO)

--- a/adafruit_rfm/rfm_common.py
+++ b/adafruit_rfm/rfm_common.py
@@ -430,7 +430,7 @@ class RFMSPI:
                 self.crc_error_count += 1
             else:
                 packet = self.read_fifo()
-                if self.radiohead:
+                if (packet is not None) and self.radiohead:
                     if len(packet) < 5:
                         # reject the packet if it is too small to contain the RAdioHead Header
                         packet = None
@@ -503,7 +503,7 @@ class RFMSPI:
                 self.crc_error_count += 1
             else:
                 packet = self.read_fifo()
-                if self.radiohead:
+                if (packet is not None) and self.radiohead:
                     if len(packet) < 5:
                         # reject the packet if it is too small to contain the RAdioHead Header
                         packet = None


### PR DESCRIPTION
fixes #5
fixes #4 

I was not able to reproduce the OP issue for #5 but the fix appears to have worked for the OP and is better coding practice.
Tested with rfm69 and rfm9x bonnets on Raspberry Pi.