### PR TITLE
Fix configuration for Spreading Factor = 6

### DIFF
--- a/adafruit_rfm/rfm9x.py
+++ b/adafruit_rfm/rfm9x.py
@@ -426,6 +426,11 @@ class RFM9x(RFMSPI):
             else:
                 self.write_u8(0x2F, 0x44)
             self.write_u8(0x30, 0)
+        # set low_datarate_optimize for signal duration > 16 ms
+        if 1000 / (self.signal_bandwidth / (1 << self.spreading_factor)) > 16:
+            self.low_datarate_optimize = 1
+        else:
+            self.low_datarate_optimize = 0
 
     @property
     def coding_rate(self) -> Literal[5, 6, 7, 8]:
@@ -473,6 +478,11 @@ class RFM9x(RFMSPI):
             _RF95_REG_1E_MODEM_CONFIG2,
             ((self.read_u8(_RF95_REG_1E_MODEM_CONFIG2) & 0x0F) | ((val << 4) & 0xF0)),
         )
+        # set low_datarate_optimize for signal duration > 16 ms
+        if 1000 / (self.signal_bandwidth / (1 << self.spreading_factor)) > 16:
+            self.low_datarate_optimize = 1
+        else:
+            self.low_datarate_optimize = 0
 
     @property
     def enable_crc(self) -> bool:

--- a/adafruit_rfm/rfm9x.py
+++ b/adafruit_rfm/rfm9x.py
@@ -496,7 +496,7 @@ class RFM9x(RFMSPI):
             )
 
     @property
-    def payload_length(self) -> bool:
+    def payload_length(self) -> int:
         """Must be set when using Implicit Header Mode - required for SF = 6"""
         return self.read_u8(_RF95_REG_22_PAYLOAD_LENGTH)
 

--- a/examples/rfm_lora_sf_base.py
+++ b/examples/rfm_lora_sf_base.py
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: 2021 ladyada for Adafruit Industries
+# SPDX-License-Identifier: MIT
+
+import time
+
+import board
+import busio
+import digitalio
+
+# Define radio parameters.
+RADIO_FREQ_MHZ = 915.0  # Frequency of the radio in Mhz. Must match your
+# module! Can be a value like 915.0, 433.0, etc.
+
+# Define pins connected to the chip, use these if wiring up the breakout according to the guide:
+CS = digitalio.DigitalInOut(board.CE1)
+RESET = digitalio.DigitalInOut(board.D25)
+
+# Initialize SPI bus.
+spi = busio.SPI(board.SCK, MOSI=board.MOSI, MISO=board.MISO)
+
+# Initialze RFM radio
+# uncommnet the desired import and rfm initialization depending on the radio boards being used
+
+# Use rfm9x for two RFM9x radios using LoRa
+
+from adafruit_rfm import rfm9x
+
+rfm = rfm9x.RFM9x(spi, CS, RESET, RADIO_FREQ_MHZ)
+
+rfm.radiohead = False  # don't appent RadioHead heade
+# set spreading factor
+rfm.spreading_factor = 6
+print("spreading factor set to :", rfm.spreading_factor)
+# rfm.ack_wait = 1
+# rfm.xmit_timeout = 5
+# rfm.low_datarate_optimize = 1
+# set node addresses
+# rfm.node = 100
+# rfm.destination = 0xFF
+rfm.enable_crc = True
+payload = bytearray(40)
+# rfm.payload_length = len(payload) + 4 # add 4 for RadioHEad header
+rfm.payload_length = len(payload)
+# send startup message from my_node
+message = bytes(f"startup message from base", "UTF-8")
+payload[0 : len(message)] = message
+rfm.send(
+    payload,
+    keep_listening=True,
+)
+# Wait to receive packets.
+print("Waiting for packets...")
+# initialize flag and timer
+transmit_delay = 5
+last_transmit_time = 0
+packet_received = False
+while True:
+    if rfm.payload_ready():
+        packet_received = False
+        packet = rfm.receive(timeout=None)
+        if packet is not None:
+            # Received a packet!
+            # Print out the raw bytes of the packet:
+            print(f"Received (raw payload): {packet}")
+            print([hex(x) for x in packet])
+            print(f"RSSI: {rfm.last_rssi}")
+            packet_received = True
+            last_transmit_time = time.monotonic()
+    if packet_received and (time.monotonic() - last_transmit_time) > transmit_delay:
+        payload = bytearray(40)
+        # message = bytes(f"packet received","UTF-8")
+        payload[0 : len(packet)] = packet
+        rfm.send(
+            payload,
+            keep_listening=True,
+        )
+        packet_received = False

--- a/examples/rfm_lora_sf_base.py
+++ b/examples/rfm_lora_sf_base.py
@@ -43,9 +43,6 @@ if rfm.spreading_factor == 12:
 elif rfm.spreading_factor > 7:
     rfm.receive_timeout = 2
 print("receive_timeout set to: ", rfm.receive_timeout)
-# set node addresses
-# rfm.node = 100
-# rfm.destination = 0xFF
 rfm.enable_crc = True
 # send startup message
 message = bytes(f"startup message from base", "UTF-8")

--- a/examples/rfm_lora_sf_node.py
+++ b/examples/rfm_lora_sf_node.py
@@ -32,12 +32,20 @@ rfm = rfm9x.RFM9x(spi, CS, RESET, RADIO_FREQ_MHZ)
 
 rfm.radiohead = False  # Do not use RadioHead Header
 # set spreading factor
-rfm.spreading_factor = 6
+rfm.spreading_factor = 7
 print("spreading factor set to :", rfm.spreading_factor)
-# rfm.ack_wait = 1
-# rfm.xmit_timeout = 5
-# rfm.low_datarate_optimize = 1
-# rfm.receive_timeout = 5
+print("low_datarate_optimize set to: ", rfm.low_datarate_optimize)
+# rfm.signal_bandwidth = 500000
+print("signal_bandwidth set to :", rfm.signal_bandwidth)
+print("low_datarate_optimize set to: ", rfm.low_datarate_optimize)
+if rfm.spreading_factor == 12:
+    rfm.xmit_timeout = 5
+print("xmit_timeout set to: ", rfm.xmit_timeout)
+if rfm.spreading_factor == 12:
+    rfm.receive_timeout = 5
+elif rfm.spreading_factor > 7:
+    rfm.receive_timeout = 2
+print("receive_timeout set to: ", rfm.receive_timeout)
 rfm.enable_crc = True
 # set the time interval (seconds) for sending packets
 transmit_interval = 10
@@ -49,11 +57,20 @@ transmit_interval = 10
 counter = 0
 ack_failed_counter = 0
 # send startup message from my_node
-payload = bytearray(40)
-rfm.payload_length = len(payload)
 message = bytes(f"startup message from node", "UTF-8")
-payload[0 : len(message)] = message
-rfm.send(payload)
+if rfm.spreading_factor == 6:
+    payload = bytearray(40)
+    rfm.payload_length = len(payload)
+    payload[0 : len(message)] = message
+    rfm.send(
+        payload,
+        keep_listening=True,
+    )
+else:
+    rfm.send(
+        message,
+        keep_listening=True,
+    )
 
 # Wait to receive packets.
 print("Waiting for packets...")
@@ -74,8 +91,19 @@ while True:
         # reset timeer
         time_now = time.monotonic()
         # send a  mesage to destination_node from my_node
-        payload = bytearray(40)
         message = bytes(f"message from node {counter}", "UTF-8")
-        payload[0 : len(message)] = message
-        rfm.send(payload)
+        if rfm.spreading_factor == 6:
+            payload = bytearray(40)
+            rfm.payload_length = len(payload)
+            payload[0 : len(message)] = message
+            rfm.send(
+                payload,
+                keep_listening=True,
+            )
+        else:
+            rfm.send(
+                message,
+                keep_listening=True,
+            )
+
         counter += 1

--- a/examples/rfm_lora_sf_node.py
+++ b/examples/rfm_lora_sf_node.py
@@ -1,0 +1,81 @@
+# SPDX-FileCopyrightText: 2021 ladyada for Adafruit Industries
+# SPDX-License-Identifier: MIT
+
+# Example to send a packet periodically between addressed nodes with ACK
+# Author: Jerry Needell
+#
+import time
+
+import board
+import busio
+import digitalio
+
+# Define radio parameters.
+RADIO_FREQ_MHZ = 915.0  # Frequency of the radio in Mhz. Must match your
+# module! Can be a value like 915.0, 433.0, etc.
+
+# Define pins connected to the chip, use these if wiring up the breakout according to the guide:
+CS = digitalio.DigitalInOut(board.CE1)
+RESET = digitalio.DigitalInOut(board.D25)
+
+# Initialize SPI bus.
+spi = busio.SPI(board.SCK, MOSI=board.MOSI, MISO=board.MISO)
+
+# Initialze RFM radio
+# uncommnet the desired import and rfm initialization depending on the radio boards being used
+
+# Use rfm9x for two RFM9x radios using LoRa
+
+from adafruit_rfm import rfm9x
+
+rfm = rfm9x.RFM9x(spi, CS, RESET, RADIO_FREQ_MHZ)
+
+rfm.radiohead = False  # Do not use RadioHead Header
+# set spreading factor
+rfm.spreading_factor = 6
+print("spreading factor set to :", rfm.spreading_factor)
+# rfm.ack_wait = 1
+# rfm.xmit_timeout = 5
+# rfm.low_datarate_optimize = 1
+# rfm.receive_timeout = 5
+rfm.enable_crc = True
+# set the time interval (seconds) for sending packets
+transmit_interval = 10
+
+# set node addresses
+# rfm.node = 1
+# rfm.destination = 100
+# initialize counter
+counter = 0
+ack_failed_counter = 0
+# send startup message from my_node
+payload = bytearray(40)
+rfm.payload_length = len(payload)
+message = bytes(f"startup message from node", "UTF-8")
+payload[0 : len(message)] = message
+rfm.send(payload)
+
+# Wait to receive packets.
+print("Waiting for packets...")
+# initialize flag and timer
+time_now = time.monotonic()
+while True:
+    # Look for a new packet: only accept if addresses to my_node
+    packet = rfm.receive()
+    # If no packet was received during the timeout then None is returned.
+    if packet is not None:
+        # Received a packet!
+        # Print out the raw bytes of the packet:
+        print(f"Received (raw payload): {packet}")
+        print([hex(x) for x in packet])
+        print(f"RSSI: {rfm.last_rssi}")
+        # send reading after any packet received
+    if time.monotonic() - time_now > transmit_interval:
+        # reset timeer
+        time_now = time.monotonic()
+        # send a  mesage to destination_node from my_node
+        payload = bytearray(40)
+        message = bytes(f"message from node {counter}", "UTF-8")
+        payload[0 : len(message)] = message
+        rfm.send(payload)
+        counter += 1


### PR DESCRIPTION
FIxes #8  
Implemented changed to rfm9x.py to correctly configure SF=6 and facilitate other SF settings

- select implicit header if SF = 6, explicit header for SF 7->12
- add property to set payload_length for SF = 6
- enable low_datarate_optimize  if the signal duration is > 16ms per data sheet 

low_datarate optimize is updated whenever the Spreading Factor or Signal Bandwidth are changed.


Added two examples for experimenting with setting the Spreading Factor:
rfm_lora_sf_base.py
rfm_lora_sf_node.py

For simplicity, The RadioHead Header is disabled for those examples.
It can be enabled if desired except that SF=6 is not currently compatible with "reliable datagram mode" (ACK).  SF = 6 requires that the sender and receiver both know the length of each packet. 
I have marked this as a "draft"  while I try to come up with a workaround.


Tested on Raspberry Pi5 and Raspberry Pi Zero W  with RFM9x Bonnets.


