### PR TITLE
Add float type hint to ack_delay member variable

### DIFF
--- a/adafruit_rfm/rfm_common.py
+++ b/adafruit_rfm/rfm_common.py
@@ -178,7 +178,7 @@ class RFMSPI:
         """
         self.ack_retries = 5
         """The number of ACK retries before reporting a failure."""
-        self.ack_delay = None
+        self.ack_delay: float = None
         """The delay time before attemting to send an ACK.
            If ACKs are being missed try setting this to .1 or .2.
         """


### PR DESCRIPTION
Hey team,

This PR resolves a minor type checking challenge that I have when using pyright. Since there is no type hint on `ack_delay`, pyright treats it as a `None` type and gripes when I attempt to assign it as a `float`. This is resolved by adding a `float` type hint to this `ack_delay` declaration. There may be other locations where this is useful but this is the only one I've found so far.
<img width="1440" alt="Captura de pantalla 2025-05-15 a la(s) 19 27 24" src="https://github.com/user-attachments/assets/caafec49-cf6d-4dc6-afc6-c05cd9e130eb" />

Thoughts?

Thanks for taking a look!