### PR TITLE
restore listen mode after ack packet set

### DIFF
--- a/adafruit_rfm/rfm_common.py
+++ b/adafruit_rfm/rfm_common.py
@@ -528,6 +528,7 @@ class RFMSPI:
                                 node=packet[0],
                                 identifier=packet[2],
                                 flags=(packet[3] | _RH_FLAGS_ACK),
+                                keep_listening=keep_listening,
                             )
                             # reject Retries if we have seen this idetifier from this source before
                             if (self.seen_ids[packet[1]] == packet[2]) and (


### PR DESCRIPTION
This is a minor change to correctly restore listen mode after sending an ACK packet in RadioHead Reliable DataGram mode.  As it is now written, in receive_with_ack,  the call to asyncio_send does not pass the "keep_listening" flag so the deafult is to go to Idle after the ack packet is sent.  A few lines of code later (likely only microseconds), the correct setting will be established when "keep_listening" is check in receive with_ack but there is an unnecessary "dead time" where the radio will be idle instead of listening. This could result in a missed packet.

I am not aware of  this actually causing any issues, but I think the  modified code is more correct.

Tested on a Raspberry Pi 5 with rfm95 bonnet.

Note: I made these changes > 6 months ago and have been using this version since then, but forgot to actually submit the PR.
