### PR TITLE
set rfm69 to idle before reading temperature

### DIFF
--- a/adafruit_rfm/rfm69.py
+++ b/adafruit_rfm/rfm69.py
@@ -310,6 +310,7 @@ class RFM69(RFMSPI):
 
         .. warning:: Reading this will STOP any receiving/sending that might be happening!
         """
+        self.idle()  # set radio idle before reading temperature
         # Start a measurement then poll the measurement finished bit.
         self.temp_start = 1
         while self.temp_running > 0:


### PR DESCRIPTION
Fixes #17 
This was also implement in the adafruit_rfm69 library see: 
(https://github.com/adafruit/Adafruit_CircuitPython_RFM69/issues/56)

I had originally thought a timeout should be added but from the datasheet, it  appears that setting the radio to Standby (idle) is what is really needed.  Section 3.4.17 of the data sheet does state ``` When temperature is measured, the receiver ADC is used to digitize the sensor response. Most receiver blocks are disabled, and temperature measurement can only be triggered in Standby or Frequency Synthesizer modes.```

Let me know if you prefer to also have a timeout implemented.